### PR TITLE
Gh67 select club dropdown component

### DIFF
--- a/client/src/pages/club-checker-page/ClubCheckerPage.module.css
+++ b/client/src/pages/club-checker-page/ClubCheckerPage.module.css
@@ -6,6 +6,7 @@
   position: relative;
   row-gap: 50px;
   width: 100%;
+  min-height: 100%;
 }
 
 .logo {

--- a/client/src/pages/create-checker-page/style.module.css
+++ b/client/src/pages/create-checker-page/style.module.css
@@ -149,8 +149,8 @@
 }
 
 .preview {
-  background-color: lightgray;
   border-radius: 20px;
+  min-height: 100%;
 }
 
 .columnsContainer {

--- a/client/src/pages/dashboard/Dashboard.tsx
+++ b/client/src/pages/dashboard/Dashboard.tsx
@@ -22,6 +22,14 @@ const CreateDashboard = () => {
 
   console.log(dashboard);
 
+  // temporary clubs array for dropdown
+  // TODO: retrieve clubs of user and create array of type DropdownClub[]
+  const testDropdownClubs = [
+    { id: 1, name: "Club 1" },
+    { id: 2, name: "Club 2" },
+    { id: 3, name: "Club 3" },
+    { id: 4, name: "Club 4" },
+  ];
   return (
     <DashboardContextProvider.Provider value={[dashboard, setDashboard]}>
       <div className={styles.dashboardContainer}>
@@ -36,14 +44,7 @@ const CreateDashboard = () => {
             <div
               className={`${styles.clubsContainer} ${styles.dashboardItemContainer}`}
             >
-              <SelectClubDropdown
-                clubs={[
-                  { id: 1, name: "Club 1" },
-                  { id: 2, name: "Club 2" },
-                  { id: 3, name: "Club 3" },
-                  { id: 4, name: "Club 4" },
-                ]}
-              />
+              <SelectClubDropdown clubs={testDropdownClubs} />
             </div>
             <div
               className={`${styles.adminShareContainer} ${styles.dashboardItemContainer}`}

--- a/client/src/pages/dashboard/Dashboard.tsx
+++ b/client/src/pages/dashboard/Dashboard.tsx
@@ -1,58 +1,76 @@
-import styles from './style.module.css';
-import WDCCLogoBlue from '../../assets/wdcc_blue_logo.svg';
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import DashboardPage from './DashboardPage';
+import styles from "./style.module.css";
+import WDCCLogoBlue from "../../assets/wdcc_blue_logo.svg";
+import React, { useState } from "react";
+import SelectClubDropdown, {
+  DropdownClub,
+} from "./components/SelectClubDropdown";
 
 export interface Dashboard {
-  checkerPage ?: string;  
-  selectedClub ?: string;
-
+  checkerPage?: string;
+  selectedClub?: DropdownClub;
 }
 
 export const DashboardContextProvider = React.createContext([{}, () => {}]);
 
 const CreateDashboard = () => {
-
   const [dashboard, setDashboard] = useState<Dashboard>(() => {
-    const storedSelectedClub = localStorage.getItem('selectedClub');
-    return storedSelectedClub ? {checkerPage: JSON.parse(storedSelectedClub)} : {};
-  }) 
+    const storedSelectedClub = localStorage.getItem("selectedClub");
+    return storedSelectedClub
+      ? { selectedClub: JSON.parse(storedSelectedClub) }
+      : {};
+  });
 
-  console.log(dashboard)
+  console.log(dashboard);
 
   return (
     <DashboardContextProvider.Provider value={[dashboard, setDashboard]}>
-      <div className={ styles.dashboardContainer }>
-        <div className={ styles.dashboardHeadingContainer }>
-          <h2 className={ styles.dashboardHeading }>dashboard</h2>
+      <div className={styles.dashboardContainer}>
+        <div className={styles.dashboardHeadingContainer}>
+          <h2 className={styles.dashboardHeading}>dashboard</h2>
 
-          <img
-              className={styles.logo}
-              src={WDCCLogoBlue}
-              alt="WDCC Logo"
-            />
+          <img className={styles.logo} src={WDCCLogoBlue} alt="WDCC Logo" />
         </div>
-        
-        <div className={ styles.gridContainer }>
-          <div className={ styles.rowOne }>
-            <div className={ `${styles.clubsContainer} ${styles.dashboardItemContainer}` }></div>
-            <div className={ `${styles.adminShareContainer} ${styles.dashboardItemContainer}` }></div>
-            <div className={ `${styles.clubAdminContainer} ${styles.dashboardItemContainer}` }></div>
+
+        <div className={styles.gridContainer}>
+          <div className={styles.rowOne}>
+            <div
+              className={`${styles.clubsContainer} ${styles.dashboardItemContainer}`}
+            >
+              <SelectClubDropdown
+                clubs={[
+                  { id: 1, name: "Club 1" },
+                  { id: 2, name: "Club 2" },
+                  { id: 3, name: "Club 3" },
+                  { id: 4, name: "Club 4" },
+                ]}
+              />
+            </div>
+            <div
+              className={`${styles.adminShareContainer} ${styles.dashboardItemContainer}`}
+            ></div>
+            <div
+              className={`${styles.clubAdminContainer} ${styles.dashboardItemContainer}`}
+            ></div>
           </div>
 
-          <div className={ styles.rowTwo }>
-            <div className={`${styles.pagePreviewContainer} ${styles.dashboardItemContainer}`}></div>
+          <div className={styles.rowTwo}>
+            <div
+              className={`${styles.pagePreviewContainer} ${styles.dashboardItemContainer}`}
+            ></div>
 
-            <div className={ styles.colTwoRowTwo }>
-              <div className={ `${styles.clubMembersContainer} ${styles.dashboardItemContainer}` }></div>
-              <div className={ `${styles.usersContainer} ${styles.dashboardItemContainer}` }></div>
+            <div className={styles.colTwoRowTwo}>
+              <div
+                className={`${styles.clubMembersContainer} ${styles.dashboardItemContainer}`}
+              ></div>
+              <div
+                className={`${styles.usersContainer} ${styles.dashboardItemContainer}`}
+              ></div>
             </div>
           </div>
-
         </div>
       </div>
     </DashboardContextProvider.Provider>
   );
-}
+};
 
 export default CreateDashboard;

--- a/client/src/pages/dashboard/Dashboard.tsx
+++ b/client/src/pages/dashboard/Dashboard.tsx
@@ -24,7 +24,7 @@ const CreateDashboard = () => {
 
   // temporary clubs array for dropdown
   // TODO: retrieve clubs of user and create array of type DropdownClub[]
-  const testDropdownClubs = [
+  const testDropdownClubs: DropdownClub[] = [
     { id: 1, name: "Club 1" },
     { id: 2, name: "Club 2" },
     { id: 3, name: "Club 3" },

--- a/client/src/pages/dashboard/components/SelectClubDropdown.module.css
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.module.css
@@ -1,9 +1,12 @@
 .outerContainer {
   border-radius: 8px 8px 0px 0px;
-  width: 250px;
+  width: 100%;
+  height: 100%;
 }
 
 .clubCard {
+  height: 100%;
+  width: 100%;
   align-items: center;
   column-gap: 10px;
   display: flex;
@@ -27,7 +30,6 @@
   font-weight: bold;
   max-height: 50px;
   overflow: hidden;
-  width: 200px;
 }
 
 .dropdownContainer {
@@ -58,4 +60,8 @@
 /* Handle on hover */
 .dropdownContainer::-webkit-scrollbar-thumb:hover {
   background: #555;
+}
+
+.clubCard:hover {
+  background-color: #e8f7fb;
 }

--- a/client/src/pages/dashboard/components/SelectClubDropdown.module.css
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.module.css
@@ -1,0 +1,56 @@
+.clubCard {
+  align-items: center;
+  column-gap: 10px;
+  cursor: pointer;
+  display: flex;
+  padding: 5px 10px;
+  /*disable highlighting of text*/
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.logo {
+  border-radius: 50%;
+  height: 45px;
+  width: 45px;
+}
+
+.text {
+  color: #03045e;
+  font-weight: bold;
+  width: 200px;
+  max-height: 50px;
+  overflow: hidden;
+}
+
+.dropdownContainer {
+  position: fixed;
+  border-radius: 0px 0px 10px 10px;
+  background-color: #d9edf1;
+  overflow-x: hidden;
+  overflow-y: auto;
+  width: inherit;
+}
+
+/* width */
+.dropdownContainer::-webkit-scrollbar {
+  width: 8px;
+}
+
+/* Track */
+.dropdownContainer::-webkit-scrollbar-track {
+  background: #d9edf1;
+}
+
+/* Handle */
+.dropdownContainer::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 5px;
+}
+
+/* Handle on hover */
+.dropdownContainer::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}

--- a/client/src/pages/dashboard/components/SelectClubDropdown.module.css
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.module.css
@@ -1,7 +1,11 @@
+.outerContainer {
+  border-radius: 8px 8px 0px 0px;
+  width: 250px;
+}
+
 .clubCard {
   align-items: center;
   column-gap: 10px;
-  cursor: pointer;
   display: flex;
   padding: 5px 10px;
   /*disable highlighting of text*/
@@ -27,7 +31,7 @@
 }
 
 .dropdownContainer {
-  background-color: #d9edf1;
+  background-color: #d6ebf0;
   border-radius: 0px 0px 10px 10px;
   overflow-x: hidden;
   overflow-y: auto;

--- a/client/src/pages/dashboard/components/SelectClubDropdown.module.css
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.module.css
@@ -19,18 +19,19 @@
 
 .text {
   color: #03045e;
+  font-family: "Montserrat", sans-serif;
   font-weight: bold;
-  width: 200px;
   max-height: 50px;
   overflow: hidden;
+  width: 200px;
 }
 
 .dropdownContainer {
-  position: fixed;
-  border-radius: 0px 0px 10px 10px;
   background-color: #d9edf1;
+  border-radius: 0px 0px 10px 10px;
   overflow-x: hidden;
   overflow-y: auto;
+  position: fixed;
   width: inherit;
 }
 

--- a/client/src/pages/dashboard/components/SelectClubDropdown.tsx
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import EmptyClubLogo from "../../../assets/EmptyClubLogo.svg";
 import styles from "./SelectClubDropdown.module.css";
-import { ArrowDown2 } from "iconsax-react";
+import { ArrowDown2, ArrowUp2 } from "iconsax-react";
 import { Dashboard, DashboardContextProvider } from "../Dashboard";
 
 interface SelectClubDropdownProps {
@@ -103,13 +103,23 @@ const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
           }
         />
         <p className={styles.text}>{dashboard.selectedClub.name}</p>
-        <ArrowDown2
-          color="#000000"
-          size={28}
-          variant="Bold"
-          style={{ cursor: "pointer", marginLeft: "auto" }}
-          onClick={() => setIsOpen(!isOpen)}
-        />
+        {isOpen ? (
+          <ArrowUp2
+            color="#000000"
+            size={28}
+            variant="Bold"
+            style={{ cursor: "pointer", marginLeft: "auto" }}
+            onClick={() => setIsOpen(!isOpen)}
+          />
+        ) : (
+          <ArrowDown2
+            color="#000000"
+            size={28}
+            variant="Bold"
+            style={{ cursor: "pointer", marginLeft: "auto" }}
+            onClick={() => setIsOpen(!isOpen)}
+          />
+        )}
       </div>
       {isOpen && (
         <div

--- a/client/src/pages/dashboard/components/SelectClubDropdown.tsx
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.tsx
@@ -62,6 +62,24 @@ const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
     };
   }, []);
 
+  // if no clubs attached to user
+  if (clubs.length == 0) {
+    return (
+      <div className={styles.outerContainer}>
+        <div
+          className={styles.clubCard}
+          style={{
+            backgroundColor: "#e8f7fb",
+            borderRadius: "8px",
+            justifyContent: "center",
+          }}
+        >
+          <p className={styles.text}>No Clubs Registered</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={styles.outerContainer}

--- a/client/src/pages/dashboard/components/SelectClubDropdown.tsx
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import EmptyClubLogo from "../../../assets/EmptyClubLogo.svg";
 import styles from "./SelectClubDropdown.module.css";
+import { ArrowDown2 } from "iconsax-react";
 
 interface SelectClubDropdownProps {
   clubs: Club[];
@@ -29,16 +30,16 @@ const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
   const clubCardHeight = 60;
   return (
     <div
-      style={{
-        width: "250px",
-        backgroundColor: "#EAF7FA",
-        borderRadius: "8px",
-      }}
+      className={styles.outerContainer}
+      style={isOpen ? { backgroundColor: "#d6ebf0" } : {}}
     >
       <div
         className={styles.clubCard}
-        style={{ height: clubCardHeight }}
-        onClick={() => setIsOpen(!isOpen)}
+        style={{
+          height: clubCardHeight,
+          backgroundColor: "#e8f7fb",
+          borderRadius: "8px",
+        }}
       >
         <img
           className={styles.logo}
@@ -50,16 +51,23 @@ const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
           }
         />
         <p className={styles.text}>{selectedClub.name}</p>
+        <ArrowDown2
+          color="#000000"
+          size={28}
+          variant="Bold"
+          style={{ cursor: "pointer" }}
+          onClick={() => setIsOpen(!isOpen)}
+        />
       </div>
       {isOpen && (
         <div
           className={styles.dropdownContainer}
-          style={{ maxHeight: 3 * clubCardHeight }}
+          style={{ maxHeight: `${3 * clubCardHeight}px` }}
         >
           {clubs.map((club) => (
             <div
               className={styles.clubCard}
-              style={{ height: clubCardHeight }}
+              style={{ height: clubCardHeight, cursor: "pointer" }}
               onClick={() => handleSelectClub(club)}
             >
               <img

--- a/client/src/pages/dashboard/components/SelectClubDropdown.tsx
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { Page } from "../../create-checker-page/CreateCheckerPage";
 import EmptyClubLogo from "../../../assets/EmptyClubLogo.svg";
 import styles from "./SelectClubDropdown.module.css";
 

--- a/client/src/pages/dashboard/components/SelectClubDropdown.tsx
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { Page } from "../../create-checker-page/CreateCheckerPage";
+import EmptyClubLogo from "../../../assets/EmptyClubLogo.svg";
+import styles from "./SelectClubDropdown.module.css";
+
+interface SelectClubDropdownProps {
+  clubs: Club[];
+}
+
+interface Club {
+  id: number;
+  name: string;
+  logo?: string;
+}
+
+const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
+  // try to retrieve selected club, if null, use first club in clubs array
+  const cachedClub = localStorage.getItem("selectedClub");
+  const [selectedClub, setSelectedClub] = useState<Club>(
+    cachedClub ? JSON.parse(cachedClub) : clubs[0]
+  );
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleSelectClub = (club: Club) => {
+    setIsOpen(!isOpen);
+    localStorage.setItem("selectedClub", JSON.stringify(club));
+    setSelectedClub(club);
+  };
+
+  const clubCardHeight = 60;
+  return (
+    <div
+      style={{
+        width: "250px",
+        backgroundColor: "#EAF7FA",
+        borderRadius: "8px",
+      }}
+    >
+      <div
+        className={styles.clubCard}
+        style={{ height: clubCardHeight }}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <img
+          className={styles.logo}
+          style={{ border: "3px solid #E0E0E0" }}
+          src={selectedClub.logo || EmptyClubLogo}
+        />
+        <p className={styles.text}>{selectedClub.name}</p>
+      </div>
+      {isOpen && (
+        <div
+          className={styles.dropdownContainer}
+          style={{ maxHeight: 3 * clubCardHeight }}
+        >
+          {clubs.map((club) => (
+            <div
+              className={styles.clubCard}
+              style={{ height: clubCardHeight }}
+              onClick={() => handleSelectClub(club)}
+            >
+              <img
+                className={styles.logo}
+                src={selectedClub.logo || EmptyClubLogo}
+              />
+              <p className={styles.text}>{club.name}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SelectClubDropdown;

--- a/client/src/pages/dashboard/components/SelectClubDropdown.tsx
+++ b/client/src/pages/dashboard/components/SelectClubDropdown.tsx
@@ -9,7 +9,7 @@ interface SelectClubDropdownProps {
 interface Club {
   id: number;
   name: string;
-  logo?: string;
+  logo?: File;
 }
 
 const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
@@ -43,7 +43,11 @@ const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
         <img
           className={styles.logo}
           style={{ border: "3px solid #E0E0E0" }}
-          src={selectedClub.logo || EmptyClubLogo}
+          src={
+            selectedClub.logo
+              ? URL.createObjectURL(selectedClub.logo)
+              : EmptyClubLogo
+          }
         />
         <p className={styles.text}>{selectedClub.name}</p>
       </div>
@@ -60,7 +64,7 @@ const SelectClubDropdown = ({ clubs }: SelectClubDropdownProps) => {
             >
               <img
                 className={styles.logo}
-                src={selectedClub.logo || EmptyClubLogo}
+                src={club.logo ? URL.createObjectURL(club.logo) : EmptyClubLogo}
               />
               <p className={styles.text}>{club.name}</p>
             </div>


### PR DESCRIPTION
## Description
Resolves #67 
  
### Acceptance Criteria
- [x] Users can see the name and logo of the dashboard's current club workspace
<img width="925" alt="image" src="https://github.com/UoaWDCC/wdcc-clubs-mem-checker/assets/100274076/fc10b3ed-9473-4f27-8f4f-78dc8ce720ff">

- [x] Users can click on the dropdown component to open a menu list
  - [x] List contains the logo and name of every club the user is an admin of
<img width="915" alt="image" src="https://github.com/UoaWDCC/wdcc-clubs-mem-checker/assets/100274076/ed99e309-8b82-4d27-ba83-f5a1a22b5312">

- [x] Users can click on a club to change their workspace to the selected club
- [x] Dropdown should fit the display of 3 clubs, and the rest will be hidden in a scrollable view
<img width="915" alt="image" src="https://github.com/UoaWDCC/wdcc-clubs-mem-checker/assets/100274076/3f5bc75d-c51b-4ae0-8d45-e43da41b5095">

- [x] Currently selected club should be stored in the browser cache when the club gets selected

--------

**Please complete the following checklist (add or update the checklist as required)**

- [ ] Breaking changes (fix that might break any existing functionalities)
- [x] Have Todo(s) that will be addressed later
- [ ] Integration/unit test(s) created and passing 
- [x] General dev testing performed
- [ ] Wiki documentation added
- [x] GitHub ticket number in PR title, PR description and branch name
