### PR TITLE
GH108 get user clubs endpoint

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -4,6 +4,7 @@ import { config } from 'dotenv';
 import authRoutes from './routes/auth/google';
 import sheetroutes from './routes/sheets/columns';
 import organisationRoutes from './routes/club/club';
+import userRoutes from './routes/user/user';
 import dashboardRoutes from './routes/dashboard/club_dashboard';
 import auth, { maybeAuth } from './middleware/auth';
 import pages from './routes/pages/pages';
@@ -47,6 +48,7 @@ app.use('/sheet/columns', sheetroutes);
 app.use('/club', organisationRoutes);
 app.use('/pages', pages);
 app.use('/dashboard', dashboardRoutes);
+app.use('/user/', userRoutes);
 
 app.get('/protected', auth, async (req, res) => {
   return res.send(`Hello, ${req.body.user.firstName}`);

--- a/api/routes/user/user.ts
+++ b/api/routes/user/user.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, UsersInOrganisation } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 import { Router } from "express";
 import auth from "../../middleware/auth";
 
@@ -9,7 +9,7 @@ router.get("/organisations", auth, async (req, res) => {
     try {
         const userOrganisations = await prisma.usersInOrganisation.findMany({
             where: {
-              userId: req.body.user.id // Replace this with the actual user ID
+              userId: req.body.user.id
             },
             select: {
               organisation: {
@@ -29,18 +29,19 @@ router.get("/organisations", auth, async (req, res) => {
               }
             }
           });
+          if (!userOrganisations) {
+            return res.status(400).send("user is not in any organisations");
+          }
           
-          // Transform the result to match the desired structure
-          const transformedOrganisations = userOrganisations.map(userOrg => ({
-            id: userOrg.organisation.id,
-            name: userOrg.organisation.name,
-            logoLink: userOrg.organisation.pages.length > 0
-              ? userOrg.organisation.pages[0].logoLink
+          const transformedOrganisations = userOrganisations.map(org => ({
+            organisationId: org.organisation.id,
+            organisationName: org.organisation.name,
+            logoLink: org.organisation.pages.length > 0
+              ? org.organisation.pages[0].logoLink
               : null
           }));
           return res.status(200).send(transformedOrganisations);   
-
-          
+ 
     }
     catch (err) {
         console.error(err);

--- a/api/routes/user/user.ts
+++ b/api/routes/user/user.ts
@@ -1,0 +1,52 @@
+import { PrismaClient, UsersInOrganisation } from "@prisma/client";
+import { Router } from "express";
+import auth from "../../middleware/auth";
+
+export const router = Router();
+const prisma = new PrismaClient();
+
+router.get("/organisations", auth, async (req, res) => {
+    try {
+        const userOrganisations = await prisma.usersInOrganisation.findMany({
+            where: {
+              userId: req.body.user.id // Replace this with the actual user ID
+            },
+            select: {
+              organisation: {
+                select: {
+                  id: true,
+                  name: true,
+                  pages: {
+                    where: {
+                      logoLink: { not: null }
+                    },
+                    take: 1,
+                    select: {
+                      logoLink: true
+                    }
+                  }
+                }
+              }
+            }
+          });
+          
+          // Transform the result to match the desired structure
+          const transformedOrganisations = userOrganisations.map(userOrg => ({
+            id: userOrg.organisation.id,
+            name: userOrg.organisation.name,
+            logoLink: userOrg.organisation.pages.length > 0
+              ? userOrg.organisation.pages[0].logoLink
+              : null
+          }));
+          return res.status(200).send(transformedOrganisations);   
+
+          
+    }
+    catch (err) {
+        console.error(err);
+        return res.status(500).send("failed to get clubs of user");
+    }
+    
+});
+
+export default router;

--- a/api/routes/user/user.yaml
+++ b/api/routes/user/user.yaml
@@ -1,0 +1,17 @@
+get:
+  security:
+    - jwt_token:
+        - 'read:users'
+        - 'read:clubs'
+  operationId: organisations
+  summary: 'Get the organisations for the requesting user'
+  tags:
+    - 'User'
+  description: 'Get an array of shallow organisation objects for the requesting user, which each contain the organisation ID, name and logolink if available, and otherwise return null'
+  responses:
+    200:
+      description: 'successfully retrieved organisations for user'
+    400:
+      description: 'user is not in any organisations'
+    500:
+      description: 'failed to get clubs of user"'


### PR DESCRIPTION
## Description
Resolves #108 
  
- [x] Returns an array of shallow club objects containing the club id, name, and logo (of the first checker page with a logo, or null if no logo) for the current user
![image](https://github.com/UoaWDCC/wdcc-clubs-mem-checker/assets/100545381/6d97791a-58b8-4d68-9bc8-525e86313d5e)
--------

**Please complete the following checklist (add or update the checklist as required)**

- [ ] Breaking changes (fix that might break any existing functionalities)
- [ ] Have Todo(s) that will be addressed later
- [ ] Integration/unit test(s) created and passing 
- [x] General dev testing performed
- [ ] Wiki documentation added
- [x] GitHub ticket number in PR title, PR description and branch name
